### PR TITLE
Fix compilation issues on RHEL7.

### DIFF
--- a/WaveBase/TFastFourierTransformFFTW.cc
+++ b/WaveBase/TFastFourierTransformFFTW.cc
@@ -105,7 +105,11 @@ TFastFourierTransformFFTW& TFastFourierTransformFFTW::GetFFT( size_t length )
 {
   FFTMap::iterator iter;
   if ( (iter = fMap.find(length)) == fMap.end() ) {
+#if __cplusplus >= 201103L
+      iter = fMap.emplace(length,TFastFourierTransformFFTW(length)).first;
+#else
       iter = fMap.insert(std::make_pair(length,TFastFourierTransformFFTW(length))).first;
+#endif
   }
   return iter->second;
 }

--- a/WaveBase/TTemplWaveform.cc
+++ b/WaveBase/TTemplWaveform.cc
@@ -309,7 +309,8 @@ TTemplWaveform<_Tp>& TTemplWaveform<_Tp>::operator=(const TObject& aWF)
   return *this;
 }
 
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L && ( (!defined(__GNUC__)) || (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9) )
+  // The GCC version check is to workaround GCC 4.8.3 from RHEL7
   #define REALFUNC std::real<double>
   #define IMAGFUNC std::imag<double>
   #define ABSFUNC  std::abs<double>


### PR DESCRIPTION
TFastFourierTransformFFTW.cc
Not sure why it failed here. Since emplace is recommended way in C++11 I made use of it.

TTemplsWaveform.cc
I didn't do a deep study what exact version begin to understand how to handle this syntax. GCC 4.8.3 obviously doesn't.
